### PR TITLE
잔액 사용 API 기능 구현 1

### DIFF
--- a/src/main/java/com/zhyun/account/controller/TransactionController.java
+++ b/src/main/java/com/zhyun/account/controller/TransactionController.java
@@ -1,0 +1,28 @@
+package com.zhyun.account.controller;
+
+import com.zhyun.account.dto.UseBalance;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 잔액 관련 컨트롤러
+ * 1. 잔액 사용
+ * 2. 잔액 사용 취소
+ * 3. 거래 확인
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class TransactionController {
+
+    @PostMapping("/transaction/use")
+    public UseBalance.Response useBalance (
+         @Valid @RequestBody UseBalance.Request request
+    ) {
+
+    }
+}

--- a/src/main/java/com/zhyun/account/controller/TransactionController.java
+++ b/src/main/java/com/zhyun/account/controller/TransactionController.java
@@ -1,6 +1,9 @@
 package com.zhyun.account.controller;
 
+import com.zhyun.account.dto.TransactionDto;
 import com.zhyun.account.dto.UseBalance;
+import com.zhyun.account.exception.AccountException;
+import com.zhyun.account.service.TransactionService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,10 +22,29 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class TransactionController {
 
+    private final TransactionService transactionService;
+
     @PostMapping("/transaction/use")
     public UseBalance.Response useBalance (
          @Valid @RequestBody UseBalance.Request request
     ) {
+        try {
+            return UseBalance.Response.from(
+                    transactionService.useBalance(
+                            request.getUserId(),
+                            request.getAccountNumber(),
+                            request.getAmount()
+                    )
+            );
+        } catch (AccountException e) {
+            log.error("Failed to use balance. ");
 
+            transactionService.saveFailedUseTransaction(
+                    request.getAccountNumber(),
+                    request.getAmount()
+            );
+
+            throw e;
+        }
     }
 }

--- a/src/main/java/com/zhyun/account/domain/Account.java
+++ b/src/main/java/com/zhyun/account/domain/Account.java
@@ -1,6 +1,8 @@
 package com.zhyun.account.domain;
 
+import com.zhyun.account.exception.AccountException;
 import com.zhyun.account.type.AccountStatus;
+import com.zhyun.account.type.ErrorCode;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -8,6 +10,8 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+
+import static com.zhyun.account.type.ErrorCode.AMOUNT_EXCEED_BALANCE;
 
 @Getter
 @Setter
@@ -34,4 +38,11 @@ public class Account {
 
     @CreatedDate      private LocalDateTime createdAt;
     @LastModifiedDate private LocalDateTime updatedAt;
+
+    public void useBalance(Long amount) {
+        if (amount > balance)
+            throw new AccountException(AMOUNT_EXCEED_BALANCE);
+
+        balance -= amount;
+    }
 }

--- a/src/main/java/com/zhyun/account/domain/Transaction.java
+++ b/src/main/java/com/zhyun/account/domain/Transaction.java
@@ -1,0 +1,44 @@
+package com.zhyun.account.domain;
+
+import com.zhyun.account.type.AccountStatus;
+import com.zhyun.account.type.TransactionResultType;
+import com.zhyun.account.type.TransactionType;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class Transaction {
+
+    @Id
+    @GeneratedValue // pk 설정
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private TransactionType transactionType;
+    @Enumerated(EnumType.STRING)
+    private TransactionResultType transactionResultType;
+
+    @ManyToOne
+    private Account account;
+    private Long amount;
+    private Long balanceSnapshot;
+
+    private String transactionId;
+    private LocalDateTime transactedAt;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/zhyun/account/dto/TransactionDto.java
+++ b/src/main/java/com/zhyun/account/dto/TransactionDto.java
@@ -1,0 +1,22 @@
+package com.zhyun.account.dto;
+
+import com.zhyun.account.type.TransactionResultType;
+import com.zhyun.account.type.TransactionType;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TransactionDto {
+    private String accountNumber;
+    private TransactionType transactionType;
+    private TransactionResultType transactionResultType;
+    private Long amount;
+    private Long balanceSnapshot;
+    private String transactionId;
+    private LocalDateTime transactedAt;
+}

--- a/src/main/java/com/zhyun/account/dto/TransactionDto.java
+++ b/src/main/java/com/zhyun/account/dto/TransactionDto.java
@@ -1,5 +1,6 @@
 package com.zhyun.account.dto;
 
+import com.zhyun.account.domain.Transaction;
 import com.zhyun.account.type.TransactionResultType;
 import com.zhyun.account.type.TransactionType;
 import lombok.*;
@@ -19,4 +20,16 @@ public class TransactionDto {
     private Long balanceSnapshot;
     private String transactionId;
     private LocalDateTime transactedAt;
+
+    public static TransactionDto fromEntity(Transaction transaction) {
+        return TransactionDto.builder()
+                .accountNumber(transaction.getAccount().getAccountNumber())
+                .transactionType(transaction.getTransactionType())
+                .transactionResultType(transaction.getTransactionResultType())
+                .amount(transaction.getAmount())
+                .balanceSnapshot(transaction.getBalanceSnapshot())
+                .transactionId(transaction.getTransactionId())
+                .transactedAt(transaction.getTransactedAt())
+                .build();
+    }
 }

--- a/src/main/java/com/zhyun/account/dto/UseBalance.java
+++ b/src/main/java/com/zhyun/account/dto/UseBalance.java
@@ -1,0 +1,43 @@
+package com.zhyun.account.dto;
+
+import com.zhyun.account.type.TransactionResultType;
+import jakarta.validation.constraints.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+public class UseBalance {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Request {
+        @NotNull
+        @Min(1)
+        private Long userId;
+
+        @NotBlank
+        @Size(min = 10, max = 10)
+        private String accountNumber;
+
+        @NotNull
+        @Min(0)
+        @Max(1000_000_000)
+        private Long amount;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+        private String accountNumber;
+        private TransactionResultType transactionResult;
+        private String transactionId;
+        private Long amount;
+        private LocalDateTime transactedAt;
+
+    }
+}

--- a/src/main/java/com/zhyun/account/dto/UseBalance.java
+++ b/src/main/java/com/zhyun/account/dto/UseBalance.java
@@ -39,5 +39,15 @@ public class UseBalance {
         private Long amount;
         private LocalDateTime transactedAt;
 
+        public static Response from(TransactionDto transactionDto) {
+            return Response.builder()
+                    .accountNumber(transactionDto.getAccountNumber())
+                    .transactionResult(transactionDto.getTransactionResultType())
+                    .transactionId(transactionDto.getTransactionId())
+                    .amount(transactionDto.getAmount())
+                    .transactedAt(transactionDto.getTransactedAt())
+                    .build();
+
+        }
     }
 }

--- a/src/main/java/com/zhyun/account/repository/TransactionRepository.java
+++ b/src/main/java/com/zhyun/account/repository/TransactionRepository.java
@@ -1,0 +1,16 @@
+package com.zhyun.account.repository;
+
+import com.zhyun.account.domain.Account;
+import com.zhyun.account.domain.AccountUser;
+import com.zhyun.account.domain.Transaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface TransactionRepository extends JpaRepository<Transaction, Long> {
+    // JpaRepository<Transaction, Long> : Transaction 엔티티 활용, Long : Transaction의 기본키 타입
+
+}

--- a/src/main/java/com/zhyun/account/service/TransactionService.java
+++ b/src/main/java/com/zhyun/account/service/TransactionService.java
@@ -1,0 +1,51 @@
+package com.zhyun.account.service;
+
+import com.zhyun.account.domain.Account;
+import com.zhyun.account.domain.AccountUser;
+import com.zhyun.account.dto.TransactionDto;
+import com.zhyun.account.exception.AccountException;
+import com.zhyun.account.repository.AccountRepository;
+import com.zhyun.account.repository.AccountUserRepository;
+import com.zhyun.account.repository.TransactionRepository;
+import com.zhyun.account.type.AccountStatus;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+
+import static com.zhyun.account.type.ErrorCode.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TransactionService {
+    private final TransactionRepository transactionRepository;
+    private final AccountUserRepository accountUserRepository;
+    private final AccountRepository accountRepository;
+
+    @Transactional
+    public TransactionDto useBalance(Long userId, String accountNumber, Long amount) {
+        AccountUser user = accountUserRepository.findById(userId)
+                .orElseThrow(() -> new AccountException(USER_NOT_FOUND));
+        Account account = accountRepository.findByAccountNumber(accountNumber)
+                .orElseThrow(() -> new AccountException(ACCOUNT_NOT_FOUND));
+
+        validateUseBalance(user, account, amount);
+
+    }
+
+    private void validateUseBalance(AccountUser user, Account account, Long amount) {
+        if (!Objects.equals(user.getId(), account.getAccountUser().getId())) {
+            throw new AccountException(USER_ACCOUNT_UN_MATCH);
+        }
+        if (account.getAccountStatus() != AccountStatus.IN_USE) {
+            throw new AccountException(ACCOUNT_ALREADY_UNREGISTERED);
+        }
+        if (account.getBalance() < amount) {
+            throw new AccountException(AMOUNT_EXCEED_BALANCE);
+        }
+
+    }
+}

--- a/src/main/java/com/zhyun/account/service/TransactionService.java
+++ b/src/main/java/com/zhyun/account/service/TransactionService.java
@@ -2,20 +2,28 @@ package com.zhyun.account.service;
 
 import com.zhyun.account.domain.Account;
 import com.zhyun.account.domain.AccountUser;
+import com.zhyun.account.domain.Transaction;
 import com.zhyun.account.dto.TransactionDto;
 import com.zhyun.account.exception.AccountException;
 import com.zhyun.account.repository.AccountRepository;
 import com.zhyun.account.repository.AccountUserRepository;
 import com.zhyun.account.repository.TransactionRepository;
 import com.zhyun.account.type.AccountStatus;
+import com.zhyun.account.type.TransactionResultType;
+import com.zhyun.account.type.TransactionType;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.Objects;
+import java.util.UUID;
 
 import static com.zhyun.account.type.ErrorCode.*;
+import static com.zhyun.account.type.TransactionResultType.F;
+import static com.zhyun.account.type.TransactionResultType.S;
+import static com.zhyun.account.type.TransactionType.USE;
 
 @Slf4j
 @Service
@@ -34,6 +42,10 @@ public class TransactionService {
 
         validateUseBalance(user, account, amount);
 
+        account.useBalance(amount);
+
+
+        return TransactionDto.fromEntity( saveAndGetTransaction(S, account, amount) );
     }
 
     private void validateUseBalance(AccountUser user, Account account, Long amount) {
@@ -47,5 +59,27 @@ public class TransactionService {
             throw new AccountException(AMOUNT_EXCEED_BALANCE);
         }
 
+    }
+
+    @Transactional
+    public void saveFailedUseTransaction(String accountNumber, Long amount) {
+        Account account = accountRepository.findByAccountNumber(accountNumber)
+                .orElseThrow(() -> new AccountException(ACCOUNT_NOT_FOUND));
+
+        saveAndGetTransaction(F, account, amount);
+    }
+
+    private Transaction saveAndGetTransaction(TransactionResultType transactionResultType, Account account, Long amount) {
+        return transactionRepository.save(
+                Transaction.builder()
+                        .transactionType(USE)
+                        .transactionResultType(transactionResultType)
+                        .account(account)
+                        .amount(amount)
+                        .balanceSnapshot(account.getBalance())
+                        .transactionId(UUID.randomUUID().toString().replace("-", ""))
+                        .transactedAt(LocalDateTime.now())
+                        .build()
+        );
     }
 }

--- a/src/main/java/com/zhyun/account/type/ErrorCode.java
+++ b/src/main/java/com/zhyun/account/type/ErrorCode.java
@@ -9,6 +9,7 @@ public enum ErrorCode {
     USER_NOT_FOUND("사용자가 없습니다."),
     MAX_ACCOUNT_PER_USER_10("사용자 최대 계좌는 10개입니다."),
     ACCOUNT_NOT_FOUND("계좌가 없습니다."),
+    AMOUNT_EXCEED_BALANCE("거래 금액이 계좌 잔액보다 큽니다."),
     USER_ACCOUNT_UN_MATCH("사용자와 계좌 주인이 다릅니다."),
     ACCOUNT_ALREADY_UNREGISTERED("계좌가 이미 해지되었습니다"),
     BALANCE_NOT_EMPTY("잔액이 있는 계좌는 해지될 수 없습니다.");

--- a/src/main/java/com/zhyun/account/type/TransactionResultType.java
+++ b/src/main/java/com/zhyun/account/type/TransactionResultType.java
@@ -1,0 +1,5 @@
+package com.zhyun.account.type;
+
+public enum TransactionResultType {
+    S, F
+}

--- a/src/main/java/com/zhyun/account/type/TransactionType.java
+++ b/src/main/java/com/zhyun/account/type/TransactionType.java
@@ -1,0 +1,5 @@
+package com.zhyun.account.type;
+
+public enum TransactionType {
+    USE, CANCEL
+}


### PR DESCRIPTION
f3502d1fddb479d590467aeef9c22592b2ef6323

### 1. top-down 개발 과정
- 트랜잭션 컨트롤러에서 요청/응답 구조를 만들고 , 컨트롤러에서 필요로 하는 서비스를 만듦
- 트랜잭션 서비스에서 엔티티를 필요로 하기 때문에 엔티티 생성
- 트랜잭션 엔티티를 사용하는 트랜잭션 리포지토리를 인터페이스로 생성
- 만든 리포지토리를 서비스에서 사용하도록 injection 해줌

### 2. 서비스 작성
- 서비스에서 잔액 사용 메서드를 정의
- 메서드의 응답으로 사용할 엔티티와 비슷한 내용의 dto 생성 후 선언해주엇다
  - dto에는 account를 accountNumber로 바꿈
- 잔액 사용 메서드에서 일어날 수 있는 예외를 validateUseBalance 메서드에 정의하여 처리

---

5cb0920db4822e3297f3c3a445b4d8523f53fe5f

### 3. 컨트롤러 useBalance 기능 구현 마무리
- account의 잔액 변경을 account 엔티티 내에서 처리하도록 로직을 작성하여 좀더 안전한 객체 구조 완성
- 서비스에서 트랜잭션을 저장해서 저장된 트랜잭션을 응답해주는 공통 메서드 saveAndGetTransaction 작성
  - 이 메서드는 거래가 실패 했을 때도 사용이 가능하도록 작성함